### PR TITLE
added a function to return all variables and their values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonlogic"
-version = "0.5.4"
+version = "0.5.5"
 authors = ["Marvin Davieds <marvin.davieds@gmail.com>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
Get the variables and their values from a jsonlogic expression. I'm using this in superposition to check if one context is a subset of another with hashset functions